### PR TITLE
Allow for additional driver options not supported in the connection string

### DIFF
--- a/packages/makeen-mongodb/src/index.js
+++ b/packages/makeen-mongodb/src/index.js
@@ -12,6 +12,7 @@ class MongoDB extends Module {
       Joi.object().keys({
         name: Joi.string().required(),
         url: Joi.string().required(),
+        driverOptions: Joi.object(),
         Store: Joi.object().default(
           () => decorators.withTimestamps(MongoStore),
           'Mongo store',
@@ -89,8 +90,8 @@ class MongoDB extends Module {
   }
 
   async createConnection(options) {
-    const { name, Store, url } = options;
-    const db = await MongoClient.connect(url);
+    const { name, Store, url, driverOptions } = options;
+    const db = await MongoClient.connect(url, driverOptions);
     const refManager = new RefManager(db);
 
     const connection = {


### PR DESCRIPTION
This will allow this module's users to specify additional configuration that can't be passed via the connection string. See http://mongodb.github.io/node-mongodb-native/2.2/reference/connecting/connection-settings/